### PR TITLE
Add command to reset data flash

### DIFF
--- a/evic/cli.py
+++ b/evic/cli.py
@@ -270,3 +270,21 @@ def convert(inputfile, output):
     with handle_exceptions(IOError):
         click.echo("Writing APROM image...", nl=False)
         output.write(binfile.convert())
+
+
+@main.command('reset-dataflash')
+def resetdataflash():
+    """Reset device data flash."""
+
+    dev = evic.HIDTransfer()
+
+    # Connect the device
+    connect(dev)
+
+    # Print the USB info of the device
+    print_usb_info(dev)
+
+    # Reset data flash
+    with handle_exceptions(IOError):
+        click.echo("Resetting data flash...", nl=False)
+        dev.reset_dataflash()

--- a/evic/device.py
+++ b/evic/device.py
@@ -220,6 +220,15 @@ class HIDTransfer(object):
 
         self.write(buf)
 
+    def reset_dataflash(self):
+        """Resets the device data flash.
+
+        Sends a data flash reset request to the firmware.
+        """
+
+        reset_df = self.hidcmd(0x7C, 0, 0)
+        self.write(reset_df)
+
     def reset(self):
         """Sends the HID command for resetting the system (0xB4)"""
 


### PR DESCRIPTION
I added HID command 0x7C, which resets the data flash. When this command is issued, the firmware resets all the data in the data flash to the default out of the box values. The only thing that is left untouched is the hardware version.
