### PR TITLE
Rework SSD1306 logo conversion, remove pillow >= 2.7.0 requirement

### DIFF
--- a/evic/logo.py
+++ b/evic/logo.py
@@ -68,10 +68,12 @@ def fromimage(image, invert=False):
 
     # Convert to paged column-major order
     # 1 bit per pixel, 8 rows per page, LSB topmost
-    imgstrips = [img.crop((0, y, 64, y + 8)) for y in range(0, 40, 8)]
+    imgpixels = img.load()
     pagedbits = bitarray(endian='little')
-    for strip in imgstrips:
-        pagedbits += list(strip.transpose(Image.TRANSPOSE).getdata())
+    for page in range(0, 5):
+        for x in range(0, 64):
+            for y in range(0, 8):
+                pagedbits.append(imgpixels[x, page*8 + y])
 
     # Invert colors
     if invert:

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ REQUIREMENTS = [
     'binstruct',
     'bitarray',
     'click',
-    'pillow>=2.7.0'
+    'pillow'
 ]
 
 setup(


### PR DESCRIPTION
Remove dependency on pillow `Image.TRANSPOSE` by rolling our own conversion loop.
