### PR TITLE
Fix logo upload for all supported devices (closes #15)

### DIFF
--- a/evic/device.py
+++ b/evic/device.py
@@ -39,6 +39,8 @@ class HIDTransfer(object):
         supported_product_ids: A dictionary mapping product ID to a list of
                                strings containing the IDs of the products
                                with compatible firmware.
+        supported_logo_size: A dictionary mapping product ID to the allowed
+                             logo resolution as a (width, height) tuple.
         hid_signature: A bytearray containing the HID command signature
                        (4 bytes).
         device: A HIDAPI device.
@@ -70,6 +72,10 @@ class HIDTransfer(object):
                              'W011': ['W011'],
                              'W013': ['W013'],
                              'W014': ['W014']}
+    supported_logo_size = {'E052': (64, 40),
+                           'E056': (64, 40),
+                           'E060': (64, 40),
+                           'M041': (96, 16)}
     # 0x43444948
     hid_signature = bytearray(b'HIDC')
 

--- a/evic/logo.py
+++ b/evic/logo.py
@@ -53,10 +53,12 @@ def fromimage(image, invert=False):
 
     img = Image.open(image)
 
-    if img.size != (64, 40):
-        raise LogoConversionError("Image dimensions must be 64x40.")
-
     width, height = img.size
+
+    if width % 8 != 0 or height % 8 != 0:
+        raise LogoConversionError("Image dimensions must be multiples of 8.")
+    if width * height > 4080:
+        raise LogoConversionError("Image is too big.")
 
     # Convert to b/w
     if img.mode != '1':
@@ -70,8 +72,8 @@ def fromimage(image, invert=False):
     # 1 bit per pixel, 8 rows per page, LSB topmost
     imgpixels = img.load()
     pagedbits = bitarray(endian='little')
-    for page in range(0, 5):
-        for x in range(0, 64):
+    for page in range(0, height / 8):
+        for x in range(0, width):
             for y in range(0, 8):
                 pagedbits.append(imgpixels[x, page*8 + y])
 


### PR DESCRIPTION
The Logo class now allows for arbitrary resolutions, as long as the
dimensions are multiples of 8 and don't exceed the buffer capacity.
Before uploading it is checked that the device actually supports logos
and that the resolution is compatible with the device.
