### PR TITLE
Fix logo conversion's division to return an integer

### DIFF
--- a/evic/logo.py
+++ b/evic/logo.py
@@ -72,7 +72,7 @@ def fromimage(image, invert=False):
     # 1 bit per pixel, 8 rows per page, LSB topmost
     imgpixels = img.load()
     pagedbits = bitarray(endian='little')
-    for page in range(0, height / 8):
+    for page in range(0, height // 8):
         for x in range(0, width):
             for y in range(0, 8):
                 pagedbits.append(imgpixels[x, page*8 + y])


### PR DESCRIPTION
with Python 3.5, i got type errors about this division, as they now return only floats. They don't suit to an integer range.

see : https://docs.python.org/3/tutorial/introduction.html#numbers
