### PR TITLE
added support for Wismec Reuleaux RX75

### DIFF
--- a/evic/device.py
+++ b/evic/device.py
@@ -69,6 +69,7 @@ class HIDTransfer(object):
                'W014': DeviceInfo("Reuleaux RX200", None, None),
                'W016': DeviceInfo("CENTURION", None, None),
                'W018': DeviceInfo("Reuleaux RX2/3", None, (64, 48)),
+               'W026': DeviceInfo("Reuleaux RX75", None, (64, 48)),
                'W033': DeviceInfo("Reuleaux RX200S", None, None)
               }
 


### PR DESCRIPTION
Added device infos for the Wismec Reuleaux RX75. Tested Firmeware update to 4.03 and logo upload as well:

$ evic-usb upload ./Reuleaux_RX75_V4.03.bin 

Finding device...OK
    Manufacturer: Nuvoton
    Product: HID Transfer
    Serial No: A02014090304

Reading data flash...OK
Verifying data flash...OK
    Device name: Reuleaux RX75
    Firmware version: 3.00
    Hardware version: 1.01

Verifying APROM...OK
Writing data flash...OK
Restarting the device...OK
Finding device...OK
Writing APROM...OK

$ evic-usb upload-logo ./LOGO.bmp

Finding device...OK
    Manufacturer: Nuvoton
    Product: HID Transfer
    Serial No: A02014090304

Reading data flash...OK
    Device name: Reuleaux RX753
    Firmware version: 4.03
    Hardware version: 1.01

Converting logo...OK
Writing data flash...OK
Restarting the device...OK
Finding device...OK
Writing logo...OK
