### PR TITLE
added support for Wismec Predator 228

### DIFF
--- a/evic/device.py
+++ b/evic/device.py
@@ -71,7 +71,8 @@ class HIDTransfer(object):
                'W016': DeviceInfo("CENTURION", None, None),
                'W018': DeviceInfo("Reuleaux RX2/3", None, (64, 48)),
                'W026': DeviceInfo("Reuleaux RX75", None, (64, 48)),
-               'W033': DeviceInfo("Reuleaux RX200S", None, None)
+               'W033': DeviceInfo("Reuleaux RX200S", None, None),
+               'W078': DeviceInfo("Predator 228", None, (64, 48))
               }
 
     # 0x43444948


### PR DESCRIPTION
I can confirm that logo upload works. I tested uploading the firmware but as there is only one firmware version available, I can only say that this gave no errors and that the device continued to work.