### PR TITLE
Added logo support for RX200s

### DIFF
--- a/evic/device.py
+++ b/evic/device.py
@@ -71,7 +71,7 @@ class HIDTransfer(object):
                'W016': DeviceInfo("CENTURION", None, None),
                'W018': DeviceInfo("Reuleaux RX2/3", None, (64, 48)),
                'W026': DeviceInfo("Reuleaux RX75", None, (64, 48)),
-               'W033': DeviceInfo("Reuleaux RX200S", None, None)
+               'W033': DeviceInfo("Reuleaux RX200S", None, (64, 48))
               }
 
     # 0x43444948


### PR DESCRIPTION
According to Wismec logo support for RX200s is supported since FW V4.02. Tested with FW 4.13.